### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/VLMEvalKit/tests/test_minimax_provider.py
+++ b/VLMEvalKit/tests/test_minimax_provider.py
@@ -13,6 +13,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 class TestMiniMaxConfig(unittest.TestCase):
     """Test MiniMax model entries in config.py registry."""
 
+    def test_m3_registered(self):
+        """MiniMax-M3 should be registered in api_models."""
+        from vlmeval.config import api_models
+        self.assertIn('MiniMax-M3', api_models)
+
     def test_m27_registered(self):
         """MiniMax-M2.7 should be registered in api_models."""
         from vlmeval.config import api_models
@@ -29,6 +34,13 @@ class TestMiniMaxConfig(unittest.TestCase):
         self.assertIn('abab6.5s', api_models)
         self.assertIn('abab7-preview', api_models)
 
+    def test_m3_api_base(self):
+        """MiniMax-M3 should use the correct api.minimax.io base URL."""
+        from vlmeval.config import api_models
+        entry = api_models['MiniMax-M3']
+        self.assertEqual(entry.keywords['api_base'],
+                         'https://api.minimax.io/v1/chat/completions')
+
     def test_m27_api_base(self):
         """MiniMax-M2.7 should use the correct api.minimax.io base URL."""
         from vlmeval.config import api_models
@@ -42,6 +54,12 @@ class TestMiniMaxConfig(unittest.TestCase):
         entry = api_models['MiniMax-M2.7-highspeed']
         self.assertEqual(entry.keywords['api_base'],
                          'https://api.minimax.io/v1/chat/completions')
+
+    def test_m3_model_name(self):
+        """MiniMax-M3 config entry should set the correct model string."""
+        from vlmeval.config import api_models
+        entry = api_models['MiniMax-M3']
+        self.assertEqual(entry.keywords['model'], 'MiniMax-M3')
 
     def test_m27_model_name(self):
         """MiniMax-M2.7 config entry should set the correct model string."""
@@ -58,7 +76,7 @@ class TestMiniMaxConfig(unittest.TestCase):
     def test_temperature_not_zero(self):
         """MiniMax models should have temperature > 0 (API constraint)."""
         from vlmeval.config import api_models
-        for name in ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'abab6.5s', 'abab7-preview']:
+        for name in ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'abab6.5s', 'abab7-preview']:
             temp = api_models[name].keywords['temperature']
             self.assertGreater(temp, 0,
                                f"{name} temperature must be > 0 for MiniMax API")
@@ -73,6 +91,11 @@ class TestMiniMaxConfig(unittest.TestCase):
             self.assertIn('api.minimax.io', url,
                           f"{name} should use api.minimax.io, not api.minimax.chat")
 
+    def test_m3_in_supported_vlm(self):
+        """MiniMax-M3 should be in the unified supported_VLM registry."""
+        from vlmeval.config import supported_VLM
+        self.assertIn('MiniMax-M3', supported_VLM)
+
     def test_m27_in_supported_vlm(self):
         """MiniMax-M2.7 models should be in the unified supported_VLM registry."""
         from vlmeval.config import supported_VLM
@@ -83,15 +106,28 @@ class TestMiniMaxConfig(unittest.TestCase):
         """MiniMax models should use GPT4V (OpenAI-compatible) wrapper."""
         from vlmeval.config import api_models
         from vlmeval.api import GPT4V
-        for name in ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed']:
+        for name in ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed']:
             entry = api_models[name]
             self.assertEqual(entry.func, GPT4V)
 
     def test_retry_count(self):
         """MiniMax models should have retry=10."""
         from vlmeval.config import api_models
-        for name in ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed']:
+        for name in ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed']:
             self.assertEqual(api_models[name].keywords['retry'], 10)
+
+    def test_m3_listed_before_legacy(self):
+        """MiniMax-M3 should be registered before older MiniMax / abab entries."""
+        from vlmeval.config import api_models
+        keys = list(api_models.keys())
+        self.assertIn('MiniMax-M3', keys)
+        m3_idx = keys.index('MiniMax-M3')
+        for older in ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'abab6.5s', 'abab7-preview']:
+            if older in keys:
+                self.assertLess(
+                    m3_idx, keys.index(older),
+                    f"MiniMax-M3 should be listed before {older}",
+                )
 
 
 class TestMiniMaxKeyDetection(unittest.TestCase):
@@ -131,6 +167,21 @@ class TestMiniMaxKeyDetection(unittest.TestCase):
         model = 'MiniMax-M2.7-highspeed'
         self.assertTrue('MiniMax-M' in model)
 
+    def test_m3_matches_condition(self):
+        """MiniMax-M3 should match the 'MiniMax-M' model name pattern."""
+        model = 'MiniMax-M3'
+        self.assertTrue('MiniMax-M' in model)
+
+    @patch.dict(os.environ, {'MiniMax_API_KEY': 'test-m3-key'}, clear=False)
+    def test_m3_detects_minimax_api_key(self):
+        """MiniMax-M3 should detect MiniMax_API_KEY env var via the same pattern."""
+        model = 'MiniMax-M3'
+        if 'abab' in model or 'MiniMax-M' in model:
+            env_key = os.environ.get('MiniMax_API_KEY', os.environ.get('MINIMAX_API_KEY', ''))
+        else:
+            env_key = ''
+        self.assertEqual(env_key, 'test-m3-key')
+
     def test_abab_still_matches(self):
         """Legacy abab models should still match the key detection condition."""
         for model in ['abab6.5s-chat', 'abab7-chat-preview']:
@@ -144,6 +195,18 @@ class TestMiniMaxKeyDetection(unittest.TestCase):
 
 class TestMiniMaxIntegration(unittest.TestCase):
     """Integration tests for MiniMax provider (require MINIMAX_API_KEY)."""
+
+    @unittest.skipUnless(
+        os.environ.get('MiniMax_API_KEY') or os.environ.get('MINIMAX_API_KEY'),
+        'MiniMax_API_KEY or MINIMAX_API_KEY not set'
+    )
+    def test_m3_generate_text(self):
+        """Integration: MiniMax-M3 should generate a text response."""
+        from vlmeval.config import supported_VLM
+        model = supported_VLM['MiniMax-M3']()
+        result = model.generate('What is 6+1? Answer with just the number.')
+        self.assertIsInstance(result, str)
+        self.assertIn('7', result)
 
     @unittest.skipUnless(
         os.environ.get('MiniMax_API_KEY') or os.environ.get('MINIMAX_API_KEY'),
@@ -168,6 +231,16 @@ class TestMiniMaxIntegration(unittest.TestCase):
         result = model.generate('What is 3+5? Answer with just the number.')
         self.assertIsInstance(result, str)
         self.assertIn('8', result)
+
+    @unittest.skipUnless(
+        os.environ.get('MiniMax_API_KEY') or os.environ.get('MINIMAX_API_KEY'),
+        'MiniMax_API_KEY or MINIMAX_API_KEY not set'
+    )
+    def test_m3_working(self):
+        """Integration: MiniMax-M3 wrapper should report as working."""
+        from vlmeval.config import supported_VLM
+        model = supported_VLM['MiniMax-M3']()
+        self.assertTrue(model.working())
 
     @unittest.skipUnless(
         os.environ.get('MiniMax_API_KEY') or os.environ.get('MINIMAX_API_KEY'),

--- a/VLMEvalKit/vlmeval/config.py
+++ b/VLMEvalKit/vlmeval/config.py
@@ -415,6 +415,13 @@ api_models = {
         GLMVisionAPI, model="glm-4v-plus-0111", temperature=0, retry=10
     ),
     # MiniMax
+    "MiniMax-M3": partial(
+        GPT4V,
+        model="MiniMax-M3",
+        api_base="https://api.minimax.io/v1/chat/completions",
+        temperature=0.01,
+        retry=10,
+    ),
     "abab6.5s": partial(
         GPT4V,
         model="abab6.5s-chat",

--- a/VLMEvalKit_ov/vlmeval/config.py
+++ b/VLMEvalKit_ov/vlmeval/config.py
@@ -410,6 +410,13 @@ api_models = {
         GLMVisionAPI, model="glm-4v-plus-0111", temperature=0, retry=10
     ),
     # MiniMax
+    "MiniMax-M3": partial(
+        GPT4V,
+        model="MiniMax-M3",
+        api_base="https://api.minimax.io/v1/chat/completions",
+        temperature=0.01,
+        retry=10,
+    ),
     "abab6.5s": partial(
         GPT4V,
         model="abab6.5s-chat",


### PR DESCRIPTION
## Summary

Upgrade the MiniMax model registration in NEO's evaluation kits to add `MiniMax-M3` as the new default option, while keeping `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` available for users who depend on the older entries.

## Changes

| File | Change |
|---|---|
| `VLMEvalKit/vlmeval/config.py` | Add `MiniMax-M3` partial entry (placed before legacy M2.7 / abab entries) |
| `VLMEvalKit_ov/vlmeval/config.py` | Same change mirrored to the NEO-ov kit |
| `VLMEvalKit/tests/test_minimax_provider.py` | Extend tests with M3 coverage (registry, api_base, model name, supported_VLM, GPT4V wrapper, retry, ordering, key detection, integration) |

`vlmeval/api/gpt.py` already routes any model whose name contains `MiniMax-M` to the `MiniMax_API_KEY` / `MINIMAX_API_KEY` env var, so no code change is needed there for M3 to inherit the existing key-detection logic.

## Why

`MiniMax-M3` is the latest MiniMax flagship model (512K context, up to 128K output, image input support) and is the recommended default for new evaluations. Listing it ahead of the older entries surfaces it as the preferred option in the registry while preserving backward compatibility for any existing scripts that pin `MiniMax-M2.7` or `MiniMax-M2.7-highspeed`.

## Test plan

- [x] `python -m unittest tests.test_minimax_provider.TestMiniMaxKeyDetection` — new `test_m3_matches_condition` and `test_m3_detects_minimax_api_key` pass
- [x] AST validation: `MiniMax-M3` registered with `partial(GPT4V, model="MiniMax-M3", api_base="https://api.minimax.io/v1/chat/completions", temperature=0.01, retry=10)` in both kits, ordered before legacy entries
- [x] Direct API smoke test confirms `MiniMax-M3` is accepted by `https://api.minimax.io/v1/chat/completions`